### PR TITLE
UrlConfig: Introduce subpage to make ListWithChatView browser history aware

### DIFF
--- a/webApp/src/main/scala/wust/webApp/state/UrlConfig.scala
+++ b/webApp/src/main/scala/wust/webApp/state/UrlConfig.scala
@@ -21,6 +21,7 @@ object InfoContent {
 final case class UrlConfig(
   view: Option[View],
   pageChange: PageChange,
+  subPage: Page,
   redirectTo: Option[View],
   shareOptions: Option[ShareOptions],
   invitation: Option[Authentication.Token],
@@ -46,5 +47,5 @@ final case class UrlConfig(
 }
 
 object UrlConfig {
-  val default = UrlConfig(view = None, pageChange = PageChange(Page.empty), redirectTo = None, shareOptions = None, invitation = None, focusId = None, mode = PresentationMode.Full, info = None)
+  val default = UrlConfig(view = None, pageChange = PageChange(Page.empty), subPage = Page.empty, redirectTo = None, shareOptions = None, invitation = None, focusId = None, mode = PresentationMode.Full, info = None)
 }

--- a/webApp/src/main/scala/wust/webApp/state/ViewConfig.scala
+++ b/webApp/src/main/scala/wust/webApp/state/ViewConfig.scala
@@ -9,7 +9,7 @@ import wust.ids.View
 // The UrlConfig is the raw configuration derived from the url.
 // The ViewConfig is the sanitized configuration for the views. For example, the
 // page in viewconfig is always consistent with the graph, i.e., it is contained in the graph
-// or else it will be none.
+// or else it will be empty.
 
 //TODO: get rid of pagechange, currently needed to know whether we should get a new graph on page change or not.
 // we only know whether we need this when changing the page. But it feels like mixing data and commands.
@@ -17,4 +17,4 @@ import wust.ids.View
 final case class ShareOptions(title: String, text: String, url: String)
 final case class PageChange(page: Page, needsGet: Boolean = true)
 
-final case class ViewConfig(view: View.Visible, page: Page)
+final case class ViewConfig(view: View.Visible, page: Page, subPage: Page)

--- a/webApp/src/main/scala/wust/webApp/views/MainView.scala
+++ b/webApp/src/main/scala/wust/webApp/views/MainView.scala
@@ -168,6 +168,11 @@ object MainView {
     // a view should never be shrinked to less than 300px-45px collapsed sidebar
     val viewWidthMod = minWidth := s"${300 - LeftSidebar.minWidthSidebar}px"
 
+    val viewAndPage = Rx {
+      val viewConfig = GlobalState.viewConfig()
+      (viewConfig.view, viewConfig.page)
+    }
+
     div(
       Styles.flex,
       Styles.growFull,
@@ -201,13 +206,13 @@ object MainView {
           Styles.growFull,
           cls := "pusher",
           Rx {
-            val viewConfig = GlobalState.viewConfig()
+            val view = viewAndPage()._1 // reacting to view and page. both will be passed into rendered views via focuState
             if (viewIsContent() && GlobalState.isLoading()) {
               spaceFillingLoadingAnimation.apply(Styles.growFull, zIndex := ZIndex.loading, backgroundColor := Colors.contentBg)
             } else if (GlobalState.showPageNotFound()) {
               PageNotFoundView.apply.apply(Styles.growFull, zIndex := ZIndex.loading, backgroundColor := Colors.contentBg)
             } else {
-              ViewRender(GlobalState.mainFocusState(viewConfig), viewConfig.view).apply(
+              ViewRender(GlobalState.mainFocusState(GlobalState.viewConfig.now), view).apply(
                 Styles.growFull,
                 flexGrow := 1
               ).prepend(


### PR DESCRIPTION
Questions:

- Should we even put `subPage` into `GlobalState.viewConfig` or would a sanitized `GlobalState.subPage` be enough?
- MainView depends on Viewconfig and therefore on view and page. But would only view be already enough, since views handle page-changes themselves?
