### PR TITLE
allow to name your entities within a node

### DIFF
--- a/ids/src/main/scala/wust/ids/NodeSettings.scala
+++ b/ids/src/main/scala/wust/ids/NodeSettings.scala
@@ -1,27 +1,37 @@
 package wust.ids
 
-final case class KanbanSettings(hideUncategorized: Boolean = false)
+// Independent of View
+final case class GlobalNodeSettings(itemNameOpt: Option[String] = None) {
+  @inline def itemName: String = itemNameOpt.getOrElse("Item")
+}
 
+object GlobalNodeSettings {
+  val default = GlobalNodeSettings()
+}
+
+final case class KanbanSettings(hideUncategorized: Boolean = false)
 object KanbanSettings {
   val default = KanbanSettings()
 }
 
 final case class TableSettings(showNested: Boolean = false)
-
 object TableSettings {
   val default = TableSettings()
 }
-final case class FormSettings(title: Option[String] = None)
 
+final case class FormSettings(title: Option[String] = None)
 object FormSettings {
   val default = FormSettings()
 }
 
 final case class NodeSettings(
+  global: Option[GlobalNodeSettings] = None,
   table: Option[TableSettings] = None,
   kanban: Option[KanbanSettings] = None,
   form: Option[FormSettings] = None
 ) {
+  def globalOrDefault = global.getOrElse(GlobalNodeSettings.default)
+  def updateGlobal(f: GlobalNodeSettings => GlobalNodeSettings): NodeSettings = copy(global = Some(f(globalOrDefault)))
   def tableOrDefault = table.getOrElse(TableSettings.default)
   def updateTable(f: TableSettings => TableSettings): NodeSettings = copy(table = Some(f(tableOrDefault)))
   def kanbanOrDefault = kanban.getOrElse(KanbanSettings.default)

--- a/webApp/src/main/scala/wust/webApp/state/FeatureDetails.scala
+++ b/webApp/src/main/scala/wust/webApp/state/FeatureDetails.scala
@@ -97,11 +97,11 @@ object FeatureDetails {
       )
       case CreateTaskInKanban => FeatureDetails (
         title = "Create Card (Kanban)",
-        description = VDomModifier(s"At the bottom of a column, click ", em(KanbanView.addCardText), " type a name in the field and press ", em("Enter"), ".")
+        description = VDomModifier("At the bottom of a column, click ", em(s"Add ${KanbanView.cardText}"), " type a name in the field and press ", em("Enter"), ".")
       )
       case CreateColumnInKanban => FeatureDetails (
         title = "Create Column (Kanban)",
-        description = VDomModifier(s"On the right side, click ", em(KanbanView.addColumnText), ", type a name in the field and press ", em("Enter"), ".")
+        description = VDomModifier("On the right side, click ", em(s"Add ${KanbanView.columnText}"), ", type a name in the field and press ", em("Enter"), ".")
       )
       case ReorderTaskInKanban => FeatureDetails (
         title = "Reorder Cards (Kanban)",

--- a/webApp/src/main/scala/wust/webApp/views/CsvHelper.scala
+++ b/webApp/src/main/scala/wust/webApp/views/CsvHelper.scala
@@ -4,6 +4,7 @@ import kantan.csv._
 import wust.graph._
 import wust.ids._
 import wust.util.collection._
+import wust.webApp.views.TableView.StaticColumns
 
 // importing and exporting from csv and table. uses kantan.csv library to parse and write csv.
 
@@ -12,6 +13,7 @@ object CsvHelper {
 
   private val multiValueSeparator = ","
 
+  //TODO: Use first column name as setting for item name
   def csvToChanges(csv: String): Either[String, GraphChanges.Import] = {
 
     def cellSplit(cell: String): Seq[String] = cell.split(multiValueSeparator).filter(_.nonEmpty)
@@ -38,7 +40,7 @@ object CsvHelper {
           header.zip(row).foreachWithIndex { case (idx, (column, cell)) =>
             // always interpret the first column as the node name
             if (idx == 0) {
-              nodes += Node.Content(nodeId, NodeData.Markdown(cell), NodeRole.Task, NodeMeta.default, None)
+              nodes += Node.Content(nodeId, NodeData.Markdown(cell), NodeRole.Task, NodeMeta.default, None, None)
               topLevelNodeIds += nodeId
             } else {
               column match {
@@ -102,7 +104,7 @@ object CsvHelper {
     // build the column header line
     val dynamicColumns = propertyGroup.properties.map(_.key)
 
-    val header = TableView.staticColumnList.map(_.title) ++ dynamicColumns
+    val header = TableView.staticColumnList(node.settings.flatMap(_.global.map(_.itemName)).getOrElse(TableView.StaticColumns.Item.tpe)).map(_.title.tpe) ++ dynamicColumns
 
     val config = CsvConfiguration.rfc.withHeader(CsvConfiguration.Header.Explicit(header))
     val stringWriter = new java.io.StringWriter

--- a/webApp/src/main/scala/wust/webApp/views/DashboardView.scala
+++ b/webApp/src/main/scala/wust/webApp/views/DashboardView.scala
@@ -30,6 +30,13 @@ object DashboardView {
 
   //TODO: button in each sidebar line to jump directly to view (conversation / tasks)
   def apply(focusState: FocusState)(implicit ctx: Ctx.Owner): VNode = {
+    val node = Rx {
+      val g = GlobalState.rawGraph()
+      g.nodesById(focusState.focusedId)
+    }
+
+    val globalNodeSettings = node.map(_.flatMap(_.settings).fold(GlobalNodeSettings.default)(_.globalOrDefault))
+
     val segmentMod = VDomModifier(
       margin := "10px"
     )
@@ -56,7 +63,10 @@ object DashboardView {
         div(
           Styles.flex,
           alignItems.flexStart,
-          h2("Your tasks", cls := "tasklist-header", marginRight.auto, Styles.flexStatic),
+          Rx {
+            //TODO: Is there a phrasing where we can use ${globalNodeSettings().itemName} (which is singular)?
+            h2(s"Your Tasks", cls := "tasklist-header", marginRight.auto, Styles.flexStatic),
+          },
           marginBottom := "15px"
         ),
         Rx {


### PR DESCRIPTION
Motivation: In our design sprint we figured that it is very important to become clear about the entity one manages. In a talk to a user, the user had initial difficulties to map a kanban card to a client. Hence I thought about it again. Furthermore we talked about the best naming for this.

This PR introduces a minimalist way of changing or naming your entity in the table view. The changes are configured and stored as a view-independent setting. The entity name is used e.g. in the kanban input and displays the name of the entity instead of a general "Item". Our conclusion of using "item" as a basis is translated into being the default setting.

![configurableEntities](https://user-images.githubusercontent.com/4647221/70150300-b9255a00-16a1-11ea-8506-884d9574b309.gif)
